### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/main/java/org/nevec/rjm/BigComplex.java
+++ b/src/main/java/org/nevec/rjm/BigComplex.java
@@ -153,7 +153,7 @@ public class BigComplex {
 	 *         The branch is chosen such that the imaginary part of the result
 	 *         has the
 	 *         same sign as the imaginary part of this.
-	 * @see Tim Ahrendt, <a href="http://dx.doi.org/10.1145/236869.236924">Fast
+	 * @see Tim Ahrendt, <a href="https://doi.org/10.1145/236869.236924">Fast
 	 *      High-precision computation of complex square roots</a>,
 	 *      ISSAC 1996 p142-149.
 	 * @since 2008-10-27

--- a/src/main/java/org/nevec/rjm/BigIntegerMath.java
+++ b/src/main/java/org/nevec/rjm/BigIntegerMath.java
@@ -580,7 +580,7 @@ public class BigIntegerMath {
 	 * @since 2009-08-06
 	 * @author Richard J. Mathar
 	 * @throws Error
-	 * @see <a href="http://dx.doi.org/10.1080/01630568908816313">P. L. Butzer
+	 * @see <a href="https://doi.org/10.1080/01630568908816313">P. L. Butzer
 	 *      et al, Num. Funct. Anal. Opt. 10 (5)( 1989) 419-488</a>
 	 */
 	static public Rational centrlFactNumt(int n, int k) throws Error {
@@ -627,7 +627,7 @@ public class BigIntegerMath {
 	 * @return T(n,k)
 	 * @since 2009-08-06
 	 * @author Richard J. Mathar
-	 * @see <a href="http://dx.doi.org/10.1080/01630568908816313">P. L. Butzer
+	 * @see <a href="https://doi.org/10.1080/01630568908816313">P. L. Butzer
 	 *      et al, Num. Funct. Anal. Opt. 10 (5)( 1989) 419-488</a>
 	 */
 	static public Rational centrlFactNumT(int n, int k) {

--- a/src/main/java/org/nevec/rjm/Wigner3j.java
+++ b/src/main/java/org/nevec/rjm/Wigner3j.java
@@ -137,7 +137,7 @@ public class Wigner3j {
 	 *            separated. Only as many as announced by the m1 parameter are
 	 *            used; trailing numbers are ignored.
 	 * @see A. Bar-Shalom and M. Klapisch,
-	 *      <a href="http://dx.doi.org/10.1016/0010-4655(88)90192-0">NJGRAF...
+	 *      <a href="https://doi.org/10.1016/0010-4655(88)90192-0">NJGRAF...
 	 *      </a>, Comp. Phys Comm. 50 (3) (1988) 375
 	 * @since 2011-02-13
 	 * @since 2012-02-15 Upgraded return value to BigSurdVec


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!